### PR TITLE
Add LaTeX class option `twocolumn` support for `bframe` env

### DIFF
--- a/lineno.sty
+++ b/lineno.sty
@@ -3420,7 +3420,7 @@ Macro file lineno.sty for LaTeX: attach line numbers, refer to them.
 %     the right margin.
 %
 %     The default definition is                                   \par$\qquad$
-%        ~\linenumberfont\hskip\linenumbersep\hskip\textwidth~    \par$\qquad$
+%        ~\linenumberfont\hskip\linenumbersep\hskip\columnwidth~  \par$\qquad$
 %        ~\hbox to\linenumberwidth{\hss\LineNumber}\hss~
 %                                                                        \item
 % [|\linenumberfont]                                                    \ \par

--- a/lineno.sty
+++ b/lineno.sty
@@ -2846,9 +2846,9 @@ Macro file lineno.sty for LaTeX: attach line numbers, refer to them.
 
 \newenvironment{bframe}
   {\par
-   \@tempdima\textwidth
+   \@tempdima\columnwidth
    \advance\@tempdima 2\bframesep
-   \setbox\bframebox\hb@xt@\textwidth{%
+   \setbox\bframebox\hb@xt@\columnwidth{%
       \hskip-\bframesep
       \vrule\@width\bframerule\@height\baselineskip\@depth\bframesep
       \advance\@tempdima-2\bframerule
@@ -2869,7 +2869,7 @@ Macro file lineno.sty for LaTeX: attach line numbers, refer to them.
    \kern-\prevdepth
    \kern\bframesep
    \nointerlineskip
-   \@tempdima\textwidth
+   \@tempdima\columnwidth
    \advance\@tempdima 2\bframesep
    \hbox{\hskip-\bframesep
          \vrule\@width\@tempdima\@height\bframerule\@depth\z@}%


### PR DESCRIPTION
It seems when `twocolumn` support was added more than 20 years ago, `bframe` was left out
https://github.com/latex-lineno/lineno/blob/b1c9f403b0febfc27a82e3036a57460a77058b9d/lineno.sty#L283

The existing `twocolumn` support can be found by searching for `\columnwidth` and `\if@twocolumn` in `lineno.sty`.

```tex
\documentclass[twocolumn]{article}
\usepackage{lineno}

\setlength{\columnsep}{50pt}
\linenumbers

\begin{document}
\def\test{
  foo\par
  bar\par
  baz

  \begin{center}\internallinenumbers
    foo\par
    bar\par
    baz
  \end{center}

  \begin{bframe}
    foo\par
    bar\par
    baz
  \end{bframe}
  \bigskip
}

\leftlinenumbers  \test
\rightlinenumbers \test
\newpage

\leftlinenumbers  \test
\rightlinenumbers \test
\end{document}
```

| Before | After |
|--------|--------|
| ![image](https://github.com/latex-lineno/lineno/assets/6376638/4905ed6f-c9aa-4ec6-a9d0-0da5776ee562) | ![image](https://github.com/latex-lineno/lineno/assets/6376638/1caed2c1-bac9-4664-8783-01d03754adf7) |
  