### PR TITLE
Fix invalid UTF-8 character

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ removed.
     **       o `Files'  and                                      **
     **       o `Installation and usage'.                       ] **
 
-    2004-09-13 Uwe L"uck  [(UL)]  is new maintainer for lineno.sty.
+    2004-09-13 Uwe Lück  [(UL)]  is new maintainer for lineno.sty.
 
     lineno.sty served the purpose for which I wrote it years ago.  Uwe
-    L"uck uses lineno.sty with his Ednotes package, which required quite a
+    Lück uses lineno.sty with his Ednotes package, which required quite a
     few changes and fixes.  His package depends on lineno, therefore
     Uwe agreed to take over the maintenance of lineno.sty.
 

--- a/edtable.sty
+++ b/edtable.sty
@@ -23,7 +23,7 @@
 %
 % The package is made for the background of the LaTeX2e macro
 % package and enhances functionality of the following packages:
-% 1.) Stephan I. B"ottcher's `lineno.sty' for printing line
+% 1.) Stephan I. Böttcher's `lineno.sty' for printing line
 %     numbers in the margin and a \label version \linelabel
 %     relating labels to line numbers;
 % 2.) our `ednotes.sty' for indicating variant readings and
@@ -178,7 +178,7 @@
 %
 %% * Acknowledgements: *
 %
-% Stephan I. B"ottcher told us how to do it in extensive discussion
+% Stephan I. Böttcher told us how to do it in extensive discussion
 % and by providing some first code lines. We changed these essentially
 % in some respects, but kept his general ideas and some parts of his
 % macros, the latter even without knowing what we are doing.

--- a/fnlineno.sty
+++ b/fnlineno.sty
@@ -20,7 +20,7 @@
 %% by the Deutsche Forschungsgemeinschaft (DFG),
 %% organized                        %% 2010/12/18 TODO!?
 %% by Prof.~Dr.\ Dr.\ Christian Tapp
-%% at Ruhr-Universit\"at Bochum, Germany.}
+%% at Ruhr-Universität Bochum, Germany.}
 %% %% 2010/12/18:
 %% Christian also has constructed some critical tests.
 %%

--- a/fnlineno.tex
+++ b/fnlineno.tex
@@ -25,9 +25,9 @@
 \maketitle
 \begin{abstract}\noindent
 'fnlineno.sty' extends
-% Stephan~I. B\"ottcher's
+% Stephan~I. Böttcher's
 \CtanPkgRef{lineno}{lineno.sty}\urlpkgfoot{lineno}
-(created by Stephan~I. B\"ottcher)
+(created by Stephan~I. Böttcher)
 such that even
 `\footnote'                                 %% `\' 2010/12/09
 lines are numbered and can be referred to

--- a/lineno.sty
+++ b/lineno.sty
@@ -289,7 +289,7 @@ Macro file lineno.sty for LaTeX: attach line numbers, refer to them.
 %% v3.08b 2002/01/27 SiB: enquotation typo fix
 %% v3.09 2003/01/14  SIB: hyperref detection fix
 %% v3.10 2003/04/15  FMi: \MakeLineNo fix for deep boxes
-%% v3.10a 2003/11/12  Uwe Lück: \lineref typo fix
+%% v3.10a 2003/11/12  Uwe LÃ¼ck: \lineref typo fix
 %% v4.00 2004/09/02  UL:  included linenox0, linenox1, lnopatch code with
 %%                        documentation, usually indicated by `New v4.00';
 %%                        discussions of old code, indicated by `UL';

--- a/lineno.sty
+++ b/lineno.sty
@@ -26,8 +26,8 @@ Macro file lineno.sty for LaTeX: attach line numbers, refer to them.
 %          A \LaTeX\ package  to attach
 % \\        line numbers to paragraphs
 %                                                            \unskip}\author{%
-%              Stephan I. B\"ottcher
-%  \\          Uwe L\"uck
+%              Stephan I. Böttcher
+%  \\          Uwe Lück
 %  \\          Karl Wette
 %                                                              \unskip}\date{%
 %            \url{https://github.com/latex-lineno/lineno}
@@ -130,10 +130,10 @@ Macro file lineno.sty for LaTeX: attach line numbers, refer to them.
 %
 % ~lineno.sty~ has been maintained by Stephan until version_v3.14.
 % From version_v4.00 onwards, maintenance is shifting towards
-% Uwe L\"uck (UL), who is the author of v4\dots code and of v4\dots
+% Uwe Lück (UL), who is the author of v4\dots code and of v4\dots
 % changes in documentation. This came about as follows.
 %
-% Since late 2002, Christian Tapp and Uwe L\"uck have employed
+% Since late 2002, Christian Tapp and Uwe Lück have employed
 % ~lineno.sty~ for their ~ednotes.sty~, a package supporting
 % critical editions, while you find ~ednotes.sty~ and surrounding files in
 % CTAN folder \path{macros/latex/contrib/ednotes}.

--- a/lnosuppl.tex
+++ b/lnosuppl.tex
@@ -5,7 +5,7 @@
        to the \textit{lineno.sty} distribution \\[1ex]
        \normalfont \Large
        Lazy \texttt{ASCII}\,$\to$\,\texttt{PDF} listings}
-\author{Uwe L\"uck}
+\author{Uwe Lück}
 \documentclass[10pt]{article}
 \usepackage{verbatim}
 %% hyperref settings from makedoc.cfg 2011/02/14:
@@ -47,7 +47,7 @@
 \section*{Preface}
 
 \texttt{lineno.sty} is a macro package made by
-Stephan~I.~B\"ottcher for attaching line numbers to
+Stephan~I.~Böttcher for attaching line numbers to
 \LaTeX\ documents. Some people have used it for revising
 submittings in collaboration with referees or co-authors.
 Documentations are nowadays preferred to be in

--- a/ulineno.tex
+++ b/ulineno.tex
@@ -24,7 +24,7 @@
 \title{           \lineno.sty
 \\                Users Manual
 }
-\author{      Stephan I. B\"ottcher
+\author{      Stephan I. Böttcher
 }
 
 \usepackage{lineno}


### PR DESCRIPTION
The character was encoded as `\xFC`, which is the valid encoding for the author's name in Latin-1 encoding. However, when UTF-8 characters were added to the file, this representation became invalid.

It triggers an annoying warning in various programs (e.g. XeLaTeX, Tectonic) for every document build. Example in _Tectonic_:
```
warning: lineno.sty:296: Invalid UTF-8 byte or sequence at line 296 replaced by U+FFFD.
```

Many other people also seem to have this problem, as similar warning is featured in their logs on the internet.
![image](https://github.com/latex-lineno/lineno/assets/26350212/501f3e35-2e8f-48d3-af72-5c317b397ef7)

Today, 12th November 2023, marks the anniversary of the line's addition. It has remained untouched for exactly 20 years.