### PR TITLE
Work around a compatibility issue of twocolumn mode againt LaTeX2e 2026-06-01 PL2 and later 

### DIFF
--- a/lineno.sty
+++ b/lineno.sty
@@ -1996,9 +1996,22 @@ Macro file lineno.sty for LaTeX: attach line numbers, refer to them.
 % routine, in order to print a column tag to the .aux
 % file.
 
-\AtBeginDocument{% v4.2, revtex4.cls (e.g.).
- % <- TODO v4.4+: Or better in \LineNoLaTeXOutput!?
+\ifdefined\IfFormatAtLeastTF \IfFormatAtLeastTF{2025-06-01}{%
+ \AtBeginDocument{%
+   %disable lineno
+   \let\@LN@makecol\@makecol
+   % replace with hook code
+   \AddToHook{build/column/before}{\protected@write\@auxout{}{%
+           \string\@LN@col{\if@firstcolumn2\else1\fi}}}
+  }}{%
+ \AtBeginDocument{%
+   \let\@LN@orig@makecol\@makecol}}
+\else
+ \AtBeginDocument{% v4.2, revtex4.cls (e.g.).
+  % <- TODO v4.4+: Or better in \LineNoLaTeXOutput!?
   \let\@LN@orig@makecol\@makecol}
+\fi
+
 \def\@LN@makecol{%
    \@LN@orig@makecol
    \setbox\@outputbox \vbox{%


### PR DESCRIPTION
Hi @kwwette,

This is based on @u-fischer's suggestion at latex3/latex2e/issues/1999 and fixes #20.

It is using a version string of `v5.5a`. 

I will do needed changes after your review.

Thanks, Akira
